### PR TITLE
fix: trigger error on Ember >= 4.x

### DIFF
--- a/addon/ext.js
+++ b/addon/ext.js
@@ -178,7 +178,7 @@ Store.reopen({
     }
 
     // invoke the ready callback ( to mimic DS.Model behaviour )
-    fragment.trigger('ready');
+    fragment.ready?.();
 
     // Add brand to reduce usages of `instanceof`
     fragment._isFragment = true;


### PR DESCRIPTION
#Task
 - Avoid `trigger` error on Ember >= 4.x
 ```error
 Uncaught (in promise) TypeError: fragment.trigger is not a function
    at StoreService.createFragment (ext.js:182:1)
    at createFragment (fragment.js:198:1)
    at FragmentRecordData.setupFragment (record-data.js:56:1)
    at FragmentRecordData.getFragment (record-data.js:65:1)
    at ManagedRiskTagModel.get (attributes.js:177:1)
    at index.js:1329:1
    at untrack (validator.js:648:1)
    at ComputedProperty.get (index.js:1328:1)
    at ManagedRiskTagModel.getter [as title] (index.js:893:1)
    at getPossibleMandatoryProxyValue (index.js:1720:1)
```